### PR TITLE
Separate zsh app files

### DIFF
--- a/.zshrc
+++ b/.zshrc
@@ -127,40 +127,22 @@ nv() {
         command nvim "$@"
     fi
 }
-# Wiki location: set $WIKI_DIR per machine (e.g. in ~/.zshenv). The `wiki`
 
-# alias is only registered when it's set.
-if [[ -n "$WIKI_DIR" ]]; then
-  alias wiki='nvim "$WIKI_DIR"'
-else
-  echo "\033[38;5;9mwarning: \$WIKI_DIR not set — 'wiki' alias not registered. Set it in ~/.zshenv (e.g. export WIKI_DIR=\"\$HOME/Documents/wiki\").\033[0m"
-  echo
-fi
-
-# wawa specific
-alias fsl="lsof -ti :7433 | xargs kill -9 && PROCFILE=Procfile.dev.local bin/dev"
-alias rubotest="bin/rubocop && bin/rspec_parallel"
-alias changedspecs="git diff --name-only | grep _spec.rb | xargs bin/rspec"
-
-# Personal laptop specific
-# SuperCollider/tidal stuff
-if [[ -x "/Applications/SuperCollider.app" ]]; then
-  alias sc='open -a SuperCollider $HOME/Music/SuperCollider/startup.scd'
-fi
-[[ -x "$HOME/.ghcup/bin/ghci" ]] && export PATH="$HOME/.ghcup/bin:$PATH"
-if command -v ghci &>/dev/null && [ -n "$(ls $HOME/.cabal/share/*/tidal-*/BootTidal.hs 2>/dev/null)" ]; then
-  alias tidal="ghci -ghci-script $(ls $HOME/.cabal/share/*/tidal-*/BootTidal.hs 2>/dev/null | tail -1)"
-  alias dirtopen='cd $HOME/Library/Application\ Support/SuperCollider/downloaded-quarks/Dirt-Samples'
-fi
-
-if command -v todoist &>/dev/null; then
-  alias t="todoist --color"
-  alias tfw='todoist --color l -p -f "#wawa"'
-  alias tfi='todoist --color l -p -f "#Inbox"'
-  alias taw='todoist --color a -N "wawa"'
-else
-  echo "\033[38;5;12mtodoist is not installed\033[0m"
-fi
+# Per-app fragments under ~/.config/zsh/. Each fragment guards itself with
+# a check for its relevant binary, app, env var, or repo path, so the file
+# can be checked in unconditionally and self-activates only on machines
+# where the guard passes. Sourced in lexical order; name fragments after
+# the app (e.g. supercollider.zsh, tidal.zsh, todoist.zsh, wawa.zsh,
+# wiki.zsh).
+#
+# New machine setup: symlink the directory so fragments are picked up —
+#   ln -s ~/Documents/github/dotfiles/zsh ~/.config/zsh
+# The (N) qualifier below makes a missing ~/.config/zsh a silent no-op, so
+# if fragments aren't running it's almost always because this symlink is
+# missing.
+for fragment in "$HOME/.config/zsh"/*.zsh(N); do
+  source "$fragment"
+done
 
 export PATH="/opt/homebrew/opt/libpq/bin:$PATH"
 

--- a/zsh/supercollider.zsh
+++ b/zsh/supercollider.zsh
@@ -1,0 +1,13 @@
+# SuperCollider / TidalCycles — only active on machines with SuperCollider
+# installed (personal laptop). Sourced from .zshrc.
+
+if [[ -x "/Applications/SuperCollider.app" ]]; then
+  alias sc='open -a SuperCollider $HOME/Music/SuperCollider/startup.scd'
+fi
+
+[[ -x "$HOME/.ghcup/bin/ghci" ]] && export PATH="$HOME/.ghcup/bin:$PATH"
+
+if command -v ghci &>/dev/null && [ -n "$(ls $HOME/.cabal/share/*/tidal-*/BootTidal.hs 2>/dev/null)" ]; then
+  alias tidal="ghci -ghci-script $(ls $HOME/.cabal/share/*/tidal-*/BootTidal.hs 2>/dev/null | tail -1)"
+  alias dirtopen='cd $HOME/Library/Application\ Support/SuperCollider/downloaded-quarks/Dirt-Samples'
+fi

--- a/zsh/todoist.zsh
+++ b/zsh/todoist.zsh
@@ -1,0 +1,10 @@
+# todoist CLI — aliases active when the binary is installed.
+
+if command -v todoist &>/dev/null; then
+  alias t="todoist --color"
+  alias tfw='todoist --color l -p -f "#wawa"'
+  alias tfi='todoist --color l -p -f "#Inbox"'
+  alias taw='todoist --color a -N "wawa"'
+else
+  echo "\033[38;5;12mtodoist is not installed\033[0m"
+fi

--- a/zsh/wawa.zsh
+++ b/zsh/wawa.zsh
@@ -1,0 +1,50 @@
+# Wawa Rails app — aliases and tmux bootstrap. Only symlinked into
+# ~/.config/zsh on the work laptop; the personal laptop doesn't symlink
+# this fragment, so no guard is needed here.
+
+alias fsl="lsof -ti :7433 | xargs kill -9 && PROCFILE=Procfile.dev.local bin/dev"
+alias rubotest="bin/rubocop && bin/rspec_parallel"
+alias changedspecs="git diff --name-only | grep _spec.rb | xargs bin/rspec"
+
+# `dev` bootstraps three tmux sessions if they don't already exist and
+# attaches to `code`:
+#
+#   code    two windows in the project root: claude, nvim
+#   server  docker / bin/rails s / bin/sidekiq, each in its own window
+#   review  two Claude sessions for PR code reviews
+#
+# Idempotent — opening a second terminal won't duplicate windows. Skip
+# the bootstrap by setting NO_TMUX=1.
+dev() {
+  [[ -n "$TMUX" ]] && return  # already inside tmux
+
+  local project="$HOME/Documents/work"
+
+  if ! tmux has-session -t code 2>/dev/null; then
+    tmux new-session -d -s code -c "$project" -n claude
+    tmux new-window  -t code:   -c "$project" -n nvim
+  fi
+
+  if ! tmux has-session -t server 2>/dev/null; then
+    tmux new-session -d -s server  -c "$project" -n docker
+    tmux new-window  -t server:    -c "$project" -n server
+    tmux new-window  -t server:    -c "$project" -n sidekiq
+  fi
+
+  if ! tmux has-session -t review 2>/dev/null; then
+    tmux new-session -d -s review -c "$project" -n claude-review
+    tmux new-window  -t review:   -c "$project" -n nvim-review
+  fi
+
+  tmux attach -t code
+}
+
+# Auto-bootstrap on interactive shell start unless we're already inside
+# tmux or NO_TMUX is set.
+if [[ -z "$TMUX" ]] && [[ $- == *i* ]] && [[ -z "$NO_TMUX" ]]; then
+  dev
+fi
+
+alias tcode="tmux attach -t code"
+alias tserv="tmux attach -t server"
+alias trev="tmux attach -t review"

--- a/zsh/wawa.zsh
+++ b/zsh/wawa.zsh
@@ -6,12 +6,13 @@ alias fsl="lsof -ti :7433 | xargs kill -9 && PROCFILE=Procfile.dev.local bin/dev
 alias rubotest="bin/rubocop && bin/rspec_parallel"
 alias changedspecs="git diff --name-only | grep _spec.rb | xargs bin/rspec"
 
-# `dev` bootstraps three tmux sessions if they don't already exist and
+# `dev` bootstraps tmux sessions if they don't already exist and
 # attaches to `code`:
 #
 #   code    two windows in the project root: claude, nvim
 #   server  docker / bin/rails s / bin/sidekiq, each in its own window
 #   review  two Claude sessions for PR code reviews
+#   wiki    single window rooted at $WIKI_DIR (skipped if unset)
 #
 # Idempotent — opening a second terminal won't duplicate windows. Skip
 # the bootstrap by setting NO_TMUX=1.
@@ -36,6 +37,10 @@ dev() {
     tmux new-window  -t review:   -c "$project" -n nvim-review
   fi
 
+  if [[ -n "$WIKI_DIR" ]] && ! tmux has-session -t wiki 2>/dev/null; then
+    tmux new-session -d -s wiki -c "$WIKI_DIR"
+  fi
+
   tmux attach -t code
 }
 
@@ -48,3 +53,4 @@ fi
 alias tcode="tmux attach -t code"
 alias tserv="tmux attach -t server"
 alias trev="tmux attach -t review"
+alias twiki="tmux attach -t wiki"

--- a/zsh/wiki.zsh
+++ b/zsh/wiki.zsh
@@ -1,0 +1,10 @@
+# Wiki: set $WIKI_DIR per machine (e.g. in ~/.zshenv). The `wiki` alias is
+# only registered when it's set; otherwise a one-line red warning prints at
+# shell start.
+
+if [[ -n "$WIKI_DIR" ]]; then
+  alias wiki='nvim "$WIKI_DIR"'
+else
+  echo "\033[38;5;9mwarning: \$WIKI_DIR not set — 'wiki' alias not registered. Set it in ~/.zshenv (e.g. export WIKI_DIR=\"\$HOME/Documents/wiki\").\033[0m"
+  echo
+fi


### PR DESCRIPTION
 Pulls the machine-specific blocks (wiki, wawa, supercollider/tidal, todoist) out of `.zshrc` into per-app fragments under `zsh/`. `.zshrc` now just loops over `~/.config/zsh/*.zsh` and sources each one. Fragments self-guard on their app, except `wawa.zsh` which is only symlinked on the work laptop.

 Also adds a `dev` function in `wawa.zsh` that bootstraps the usual tmux sessions (`code`, `server`, `review`, `wiki`) on shell start.
